### PR TITLE
fix `ReferenceError: AbortController is not defined` error for NodeJS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.1
+
+- fix `ReferenceError: AbortController is not defined` error for NodeJS less than v.15
+
 ## 1.4.0
 
 - extend config with `doNotRetryIfStatuses` option

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "retry-my-fetch",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retry-my-fetch",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/abort-controller/index.ts
+++ b/src/abort-controller/index.ts
@@ -5,5 +5,13 @@ export default {
   set: (controller: AbortController): void => {
     instance = controller;
   },
-  isAvailable: (): boolean => !!instance || !!AbortController,
+  isAvailable: (): boolean => {
+    let isAbortControllerAvailable;
+    try {
+      isAbortControllerAvailable = !!new AbortController();
+    } catch (_) {
+      isAbortControllerAvailable = false;
+    }
+    return !!instance || isAbortControllerAvailable;
+  },
 };


### PR DESCRIPTION
… less than v.15